### PR TITLE
Add green and purple themed calculator

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Green &amp; Purple Calculator</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="app">
+      <section class="calculator" aria-label="Calculator">
+        <header class="display" aria-live="polite">
+          <div class="expression" id="expression" aria-hidden="true"></div>
+          <output class="result" id="result" role="status" aria-live="polite">0</output>
+        </header>
+        <div class="keys" role="group" aria-label="Calculator keys">
+          <button type="button" class="key key--function" data-action="clear">AC</button>
+          <button type="button" class="key key--function" data-action="sign">±</button>
+          <button type="button" class="key key--function" data-action="percent">%</button>
+          <button type="button" class="key key--operator" data-operator="/">÷</button>
+
+          <button type="button" class="key" data-digit="7">7</button>
+          <button type="button" class="key" data-digit="8">8</button>
+          <button type="button" class="key" data-digit="9">9</button>
+          <button type="button" class="key key--operator" data-operator="*">×</button>
+
+          <button type="button" class="key" data-digit="4">4</button>
+          <button type="button" class="key" data-digit="5">5</button>
+          <button type="button" class="key" data-digit="6">6</button>
+          <button type="button" class="key key--operator" data-operator="-">−</button>
+
+          <button type="button" class="key" data-digit="1">1</button>
+          <button type="button" class="key" data-digit="2">2</button>
+          <button type="button" class="key" data-digit="3">3</button>
+          <button type="button" class="key key--operator" data-operator="+">+</button>
+
+          <button type="button" class="key key--wide" data-digit="0">0</button>
+          <button type="button" class="key" data-digit=".">.</button>
+          <button type="button" class="key key--operator" data-action="equals">=</button>
+        </div>
+      </section>
+    </main>
+    <script src="script.js" type="module"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,214 @@
+const resultEl = document.querySelector('#result');
+const expressionEl = document.querySelector('#expression');
+const keysEl = document.querySelector('.keys');
+
+const state = {
+  current: '0',
+  previous: null,
+  operator: null,
+  overwrite: false,
+};
+
+function updateDisplay() {
+  resultEl.textContent = state.current;
+
+  if (state.operator && state.previous !== null) {
+    expressionEl.textContent = `${state.previous} ${symbolForOperator(state.operator)}`;
+  } else {
+    expressionEl.textContent = '';
+  }
+}
+
+function symbolForOperator(operator) {
+  return (
+    {
+      '+': '+',
+      '-': '−',
+      '*': '×',
+      '/': '÷',
+    }[operator] || ''
+  );
+}
+
+function inputDigit(digit) {
+  if (state.overwrite) {
+    state.current = digit === '.' ? '0.' : digit;
+    state.overwrite = false;
+    updateDisplay();
+    return;
+  }
+
+  if (digit === '.') {
+    if (!state.current.includes('.')) {
+      state.current += '.';
+    }
+  } else {
+    state.current = state.current === '0' ? digit : state.current + digit;
+  }
+
+  updateDisplay();
+}
+
+function clearState() {
+  state.current = '0';
+  state.previous = null;
+  state.operator = null;
+  state.overwrite = false;
+  updateDisplay();
+}
+
+function toggleSign() {
+  if (state.current === '0') return;
+  state.current = state.current.startsWith('-')
+    ? state.current.slice(1)
+    : `-${state.current}`;
+  updateDisplay();
+}
+
+function applyPercent() {
+  const value = parseFloat(state.current);
+  if (Number.isNaN(value)) return;
+  state.current = (value / 100).toString();
+  updateDisplay();
+}
+
+function setOperator(operator) {
+  const currentValue = parseFloat(state.current);
+
+  if (state.operator && state.previous !== null && !state.overwrite) {
+    const result = evaluate(state.previous, currentValue, state.operator);
+    if (result !== null) {
+      state.previous = result;
+      state.current = String(result);
+    }
+  } else {
+    state.previous = currentValue;
+  }
+
+  state.operator = operator;
+  state.overwrite = true;
+  updateDisplay();
+}
+
+function evaluate(previous, current, operator) {
+  let result = null;
+  switch (operator) {
+    case '+':
+      result = previous + current;
+      break;
+    case '-':
+      result = previous - current;
+      break;
+    case '*':
+      result = previous * current;
+      break;
+    case '/':
+      if (current === 0) {
+        resultEl.textContent = 'Nope';
+        expressionEl.textContent = '';
+        state.current = '0';
+        state.previous = null;
+        state.operator = null;
+        state.overwrite = true;
+        return null;
+      }
+      result = previous / current;
+      break;
+    default:
+      return null;
+  }
+  return parseFloat(result.toFixed(10));
+}
+
+function handleEquals() {
+  if (state.operator === null || state.previous === null) {
+    return;
+  }
+  const currentValue = parseFloat(state.current);
+  const computation = evaluate(state.previous, currentValue, state.operator);
+  if (computation === null) {
+    return;
+  }
+  state.current = String(computation);
+  state.previous = null;
+  state.operator = null;
+  state.overwrite = true;
+  updateDisplay();
+}
+
+function handleKey({ target }) {
+  if (!(target instanceof HTMLButtonElement)) return;
+
+  if (target.dataset.digit) {
+    inputDigit(target.dataset.digit);
+    return;
+  }
+
+  if (target.dataset.operator) {
+    setOperator(target.dataset.operator);
+    return;
+  }
+
+  switch (target.dataset.action) {
+    case 'clear':
+      clearState();
+      break;
+    case 'sign':
+      toggleSign();
+      break;
+    case 'percent':
+      applyPercent();
+      break;
+    case 'equals':
+      handleEquals();
+      break;
+    default:
+      break;
+  }
+}
+
+function handleKeyboard(event) {
+  const { key } = event;
+
+  if (/[0-9]/.test(key)) {
+    inputDigit(key);
+    return;
+  }
+
+  if (key === '.') {
+    inputDigit(key);
+    return;
+  }
+
+  if (['+', '-', '*', '/'].includes(key)) {
+    event.preventDefault();
+    setOperator(key);
+    return;
+  }
+
+  if (key === 'Enter' || key === '=') {
+    event.preventDefault();
+    handleEquals();
+    return;
+  }
+
+  if (key === 'Backspace') {
+    if (state.overwrite || state.current.length === 1) {
+      state.current = '0';
+    } else {
+      state.current = state.current.slice(0, -1);
+    }
+    state.overwrite = false;
+    updateDisplay();
+    return;
+  }
+
+  if (key === 'Escape') {
+    clearState();
+  }
+}
+
+keysEl.addEventListener('click', handleKey);
+window.addEventListener('keydown', handleKeyboard);
+
+updateDisplay();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,129 @@
+:root {
+  color-scheme: light;
+  font-family: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+  --green-900: #0f3d33;
+  --green-500: #3eb489;
+  --green-300: #68d6a8;
+  --purple-900: #2b0a3d;
+  --purple-600: #662c91;
+  --purple-400: #9c4dcc;
+  --surface: #f4f5fb;
+  --text-primary: #ffffff;
+  --text-secondary: rgba(255, 255, 255, 0.7);
+  --shadow: 0 22px 45px rgba(43, 10, 61, 0.35);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: radial-gradient(circle at top left, var(--green-300), var(--purple-600));
+  color: var(--text-primary);
+}
+
+.app {
+  padding: 2rem 1.5rem;
+  width: min(420px, calc(100% - 2rem));
+}
+
+.calculator {
+  background: linear-gradient(160deg, var(--green-900), var(--purple-900));
+  border-radius: 32px;
+  box-shadow: var(--shadow);
+  padding: 1.75rem 1.5rem 1.5rem;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.display {
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 24px;
+  padding: 1.25rem 1.5rem;
+  text-align: right;
+  min-height: 96px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.45rem;
+}
+
+.expression {
+  font-size: 1rem;
+  font-weight: 400;
+  color: var(--text-secondary);
+  min-height: 1.5em;
+  overflow-wrap: anywhere;
+}
+
+.result {
+  font-size: clamp(2.5rem, 6vw, 3.2rem);
+  font-weight: 600;
+  letter-spacing: 0.05em;
+}
+
+.keys {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.key {
+  background: rgba(255, 255, 255, 0.12);
+  border: none;
+  color: inherit;
+  border-radius: 20px;
+  font-size: 1.35rem;
+  font-weight: 500;
+  padding: 1rem;
+  transition: transform 0.12s ease, box-shadow 0.12s ease, background-color 0.12s ease;
+  cursor: pointer;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+}
+
+.key:focus-visible {
+  outline: 3px solid var(--green-300);
+  outline-offset: 3px;
+}
+
+.key:active {
+  transform: scale(0.98);
+}
+
+.key--function {
+  background: rgba(62, 180, 137, 0.35);
+  color: #ebfff6;
+}
+
+.key--operator {
+  background: linear-gradient(120deg, var(--purple-400), var(--green-500));
+  color: #fef6ff;
+  font-weight: 600;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.25);
+}
+
+.key--operator[data-action='equals'] {
+  background: linear-gradient(120deg, var(--green-500), var(--purple-600));
+}
+
+.key--wide {
+  grid-column: span 2;
+}
+
+@media (max-width: 480px) {
+  .calculator {
+    border-radius: 24px;
+    padding: 1.25rem 1rem 1rem;
+  }
+
+  .key {
+    border-radius: 16px;
+    font-size: 1.2rem;
+    padding: 0.9rem 0.85rem;
+  }
+}


### PR DESCRIPTION
## Summary
- build a standalone calculator page with a vibrant green and purple aesthetic
- implement calculator logic including chaining operations, percent, sign toggle, and keyboard support
- style the layout with responsive gradients and accessible focus treatments

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d38f701774832d823fc04a96af801e