### PR TITLE
Create scroll-responsive thermometer experience

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,47 +3,68 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Green &amp; Purple Calculator</title>
+    <title>Scroll Heat Thermometer</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap"
       rel="stylesheet"
     />
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-    <main class="app">
-      <section class="calculator" aria-label="Calculator">
-        <header class="display" aria-live="polite">
-          <div class="expression" id="expression" aria-hidden="true"></div>
-          <output class="result" id="result" role="status" aria-live="polite">0</output>
-        </header>
-        <div class="keys" role="group" aria-label="Calculator keys">
-          <button type="button" class="key key--function" data-action="clear">AC</button>
-          <button type="button" class="key key--function" data-action="sign">±</button>
-          <button type="button" class="key key--function" data-action="percent">%</button>
-          <button type="button" class="key key--operator" data-operator="/">÷</button>
+    <main class="page" aria-label="Scroll activated heat counter">
+      <section class="hero">
+        <p class="eyebrow">Scroll to warm things up</p>
+        <div class="counter" id="counter" aria-live="polite">0</div>
+        <p class="subtitle">
+          Each swipe turns up the heat and charges the city for a sunrise.
+        </p>
+        <div class="scroll-hint" aria-hidden="true">Keep swiping ↓</div>
+      </section>
 
-          <button type="button" class="key" data-digit="7">7</button>
-          <button type="button" class="key" data-digit="8">8</button>
-          <button type="button" class="key" data-digit="9">9</button>
-          <button type="button" class="key key--operator" data-operator="*">×</button>
-
-          <button type="button" class="key" data-digit="4">4</button>
-          <button type="button" class="key" data-digit="5">5</button>
-          <button type="button" class="key" data-digit="6">6</button>
-          <button type="button" class="key key--operator" data-operator="-">−</button>
-
-          <button type="button" class="key" data-digit="1">1</button>
-          <button type="button" class="key" data-digit="2">2</button>
-          <button type="button" class="key" data-digit="3">3</button>
-          <button type="button" class="key key--operator" data-operator="+">+</button>
-
-          <button type="button" class="key key--wide" data-digit="0">0</button>
-          <button type="button" class="key" data-digit=".">.</button>
-          <button type="button" class="key key--operator" data-action="equals">=</button>
+      <section class="thermometer-card">
+        <h2 class="thermometer-title">Ambient Energy Thermometer</h2>
+        <div class="thermometer" id="thermometer" role="presentation">
+          <div class="thermometer__stem">
+            <div class="thermometer__track">
+              <div class="thermometer__fill" id="thermometerFill"></div>
+            </div>
+          </div>
+          <div class="thermometer__bulb" id="thermometerBulb"></div>
         </div>
+        <div class="temperature-readout" aria-live="polite">
+          <span class="temperature-value" id="temperatureValue">0%</span>
+          warmed
+        </div>
+      </section>
+
+      <section class="story">
+        <h2>Gather momentum</h2>
+        <p>
+          The higher the counter climbs, the more energy flows into the virtual
+          grid. Imagine thousands of small generators feeding a single city
+          block. Every scroll is another pulse of power raising the collective
+          temperature.
+        </p>
+      </section>
+
+      <section class="story">
+        <h2>Watch the color shift</h2>
+        <p>
+          The thermometer moves through a gradient from arctic blue to molten
+          red. The stem reacts instantly as your scroll adds more charge. Slow
+          down to hover in the balmy midtones or race toward the blazing peak.
+        </p>
+      </section>
+
+      <section class="story">
+        <h2>Reach the summit</h2>
+        <p>
+          When the counter maxes out, the bar glows in vivid crimson, showing
+          that the grid is fully energized. Scroll back up to cool things off,
+          or run it again to watch the transition unfold.
+        </p>
       </section>
     </main>
     <script src="script.js" type="module"></script>

--- a/script.js
+++ b/script.js
@@ -1,214 +1,89 @@
-const resultEl = document.querySelector('#result');
-const expressionEl = document.querySelector('#expression');
-const keysEl = document.querySelector('.keys');
+const counterEl = document.querySelector('#counter');
+const thermometerEl = document.querySelector('#thermometer');
+const fillEl = document.querySelector('#thermometerFill');
+const bulbEl = document.querySelector('#thermometerBulb');
+const temperatureEl = document.querySelector('#temperatureValue');
 
-const state = {
-  current: '0',
-  previous: null,
-  operator: null,
-  overwrite: false,
-};
+const MAX_COUNT = 50000;
+const COLOR_START = { h: 205, s: 86, l: 58 }; // chilly blue
+const COLOR_END = { h: 5, s: 88, l: 52 }; // molten red
 
-function updateDisplay() {
-  resultEl.textContent = state.current;
+let ticking = false;
 
-  if (state.operator && state.previous !== null) {
-    expressionEl.textContent = `${state.previous} ${symbolForOperator(state.operator)}`;
-  } else {
-    expressionEl.textContent = '';
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function lerp(start, end, t) {
+  return start + (end - start) * t;
+}
+
+function hslToCss({ h, s, l }) {
+  return `hsl(${h.toFixed(1)}, ${s.toFixed(1)}%, ${l.toFixed(1)}%)`;
+}
+
+function mixColor(t) {
+  return {
+    h: lerp(COLOR_START.h, COLOR_END.h, t),
+    s: lerp(COLOR_START.s, COLOR_END.s, t),
+    l: lerp(COLOR_START.l, COLOR_END.l, t),
+  };
+}
+
+function adjustLightness(color, delta) {
+  return { ...color, l: clamp(color.l + delta, 0, 100) };
+}
+
+function updateVisuals(progress) {
+  const eased = progress ** 1.15;
+  const count = Math.round(eased * MAX_COUNT);
+  const percent = Math.round(progress * 100);
+
+  counterEl.textContent = count.toLocaleString('en-US');
+  temperatureEl.textContent = `${percent}%`;
+
+  thermometerEl.style.setProperty('--fill-progress', eased.toString());
+
+  const color = mixColor(progress);
+  const lightColor = adjustLightness(color, 18);
+  const glowColor = adjustLightness(color, -12);
+
+  const colorCss = hslToCss(color);
+  const lightCss = hslToCss(lightColor);
+  const glowCss = hslToCss(glowColor);
+
+  thermometerEl.style.setProperty('--fill-color', colorCss);
+  thermometerEl.style.setProperty('--fill-color-light', lightCss);
+
+  fillEl.style.boxShadow = `0 0 30px ${colorCss}`;
+  bulbEl.style.background = colorCss;
+  bulbEl.style.boxShadow = `inset 0 -10px 30px rgba(15, 23, 42, 0.4), 0 18px 45px ${glowCss}`;
+}
+
+function calculateProgress() {
+  const doc = document.documentElement;
+  const scrollable = doc.scrollHeight - window.innerHeight;
+  if (scrollable <= 0) {
+    return 0;
+  }
+  const progress = window.scrollY / scrollable;
+  return clamp(progress, 0, 1);
+}
+
+function handleScroll() {
+  if (!ticking) {
+    window.requestAnimationFrame(() => {
+      const progress = calculateProgress();
+      updateVisuals(progress);
+      ticking = false;
+    });
+    ticking = true;
   }
 }
 
-function symbolForOperator(operator) {
-  return (
-    {
-      '+': '+',
-      '-': '−',
-      '*': '×',
-      '/': '÷',
-    }[operator] || ''
-  );
-}
+window.addEventListener('scroll', handleScroll, { passive: true });
+window.addEventListener('resize', handleScroll);
 
-function inputDigit(digit) {
-  if (state.overwrite) {
-    state.current = digit === '.' ? '0.' : digit;
-    state.overwrite = false;
-    updateDisplay();
-    return;
-  }
-
-  if (digit === '.') {
-    if (!state.current.includes('.')) {
-      state.current += '.';
-    }
-  } else {
-    state.current = state.current === '0' ? digit : state.current + digit;
-  }
-
-  updateDisplay();
-}
-
-function clearState() {
-  state.current = '0';
-  state.previous = null;
-  state.operator = null;
-  state.overwrite = false;
-  updateDisplay();
-}
-
-function toggleSign() {
-  if (state.current === '0') return;
-  state.current = state.current.startsWith('-')
-    ? state.current.slice(1)
-    : `-${state.current}`;
-  updateDisplay();
-}
-
-function applyPercent() {
-  const value = parseFloat(state.current);
-  if (Number.isNaN(value)) return;
-  state.current = (value / 100).toString();
-  updateDisplay();
-}
-
-function setOperator(operator) {
-  const currentValue = parseFloat(state.current);
-
-  if (state.operator && state.previous !== null && !state.overwrite) {
-    const result = evaluate(state.previous, currentValue, state.operator);
-    if (result !== null) {
-      state.previous = result;
-      state.current = String(result);
-    }
-  } else {
-    state.previous = currentValue;
-  }
-
-  state.operator = operator;
-  state.overwrite = true;
-  updateDisplay();
-}
-
-function evaluate(previous, current, operator) {
-  let result = null;
-  switch (operator) {
-    case '+':
-      result = previous + current;
-      break;
-    case '-':
-      result = previous - current;
-      break;
-    case '*':
-      result = previous * current;
-      break;
-    case '/':
-      if (current === 0) {
-        resultEl.textContent = 'Nope';
-        expressionEl.textContent = '';
-        state.current = '0';
-        state.previous = null;
-        state.operator = null;
-        state.overwrite = true;
-        return null;
-      }
-      result = previous / current;
-      break;
-    default:
-      return null;
-  }
-  return parseFloat(result.toFixed(10));
-}
-
-function handleEquals() {
-  if (state.operator === null || state.previous === null) {
-    return;
-  }
-  const currentValue = parseFloat(state.current);
-  const computation = evaluate(state.previous, currentValue, state.operator);
-  if (computation === null) {
-    return;
-  }
-  state.current = String(computation);
-  state.previous = null;
-  state.operator = null;
-  state.overwrite = true;
-  updateDisplay();
-}
-
-function handleKey({ target }) {
-  if (!(target instanceof HTMLButtonElement)) return;
-
-  if (target.dataset.digit) {
-    inputDigit(target.dataset.digit);
-    return;
-  }
-
-  if (target.dataset.operator) {
-    setOperator(target.dataset.operator);
-    return;
-  }
-
-  switch (target.dataset.action) {
-    case 'clear':
-      clearState();
-      break;
-    case 'sign':
-      toggleSign();
-      break;
-    case 'percent':
-      applyPercent();
-      break;
-    case 'equals':
-      handleEquals();
-      break;
-    default:
-      break;
-  }
-}
-
-function handleKeyboard(event) {
-  const { key } = event;
-
-  if (/[0-9]/.test(key)) {
-    inputDigit(key);
-    return;
-  }
-
-  if (key === '.') {
-    inputDigit(key);
-    return;
-  }
-
-  if (['+', '-', '*', '/'].includes(key)) {
-    event.preventDefault();
-    setOperator(key);
-    return;
-  }
-
-  if (key === 'Enter' || key === '=') {
-    event.preventDefault();
-    handleEquals();
-    return;
-  }
-
-  if (key === 'Backspace') {
-    if (state.overwrite || state.current.length === 1) {
-      state.current = '0';
-    } else {
-      state.current = state.current.slice(0, -1);
-    }
-    state.overwrite = false;
-    updateDisplay();
-    return;
-  }
-
-  if (key === 'Escape') {
-    clearState();
-  }
-}
-
-keysEl.addEventListener('click', handleKey);
-window.addEventListener('keydown', handleKeyboard);
-
-updateDisplay();
+document.addEventListener('DOMContentLoaded', () => {
+  updateVisuals(calculateProgress());
+});

--- a/styles.css
+++ b/styles.css
@@ -1,17 +1,14 @@
 :root {
   color-scheme: light;
-  font-family: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-    sans-serif;
-  --green-900: #0f3d33;
-  --green-500: #3eb489;
-  --green-300: #68d6a8;
-  --purple-900: #2b0a3d;
-  --purple-600: #662c91;
-  --purple-400: #9c4dcc;
-  --surface: #f4f5fb;
-  --text-primary: #ffffff;
-  --text-secondary: rgba(255, 255, 255, 0.7);
-  --shadow: 0 22px 45px rgba(43, 10, 61, 0.35);
+  font-family: 'Plus Jakarta Sans', system-ui, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', sans-serif;
+  --background-top: #0b1226;
+  --background-bottom: #020617;
+  --text-primary: #f8fafc;
+  --text-secondary: rgba(226, 232, 240, 0.75);
+  --card-surface: rgba(15, 23, 42, 0.65);
+  --card-border: rgba(148, 163, 184, 0.25);
+  --shadow-soft: 0 24px 60px rgba(15, 23, 42, 0.45);
 }
 
 * {
@@ -21,109 +18,166 @@
 body {
   margin: 0;
   min-height: 100vh;
-  display: grid;
-  place-items: center;
-  background: radial-gradient(circle at top left, var(--green-300), var(--purple-600));
+  background: linear-gradient(180deg, var(--background-top), var(--background-bottom));
   color: var(--text-primary);
 }
 
-.app {
-  padding: 2rem 1.5rem;
-  width: min(420px, calc(100% - 2rem));
+.page {
+  width: min(520px, 100%);
+  margin: 0 auto;
+  padding: clamp(1.75rem, 6vw, 3rem) clamp(1.25rem, 7vw, 3.25rem) 6rem;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2.5rem, 8vw, 4rem);
 }
 
-.calculator {
-  background: linear-gradient(160deg, var(--green-900), var(--purple-900));
-  border-radius: 32px;
-  box-shadow: var(--shadow);
-  padding: 1.75rem 1.5rem 1.5rem;
+.hero,
+.thermometer-card,
+.story {
+  background: var(--card-surface);
+  border: 1px solid var(--card-border);
+  border-radius: 28px;
+  box-shadow: var(--shadow-soft);
+  padding: clamp(1.75rem, 6vw, 2.75rem);
+  backdrop-filter: blur(12px);
+}
+
+.hero {
+  text-align: center;
   display: grid;
   gap: 1.25rem;
 }
 
-.display {
-  background: rgba(255, 255, 255, 0.08);
-  border-radius: 24px;
-  padding: 1.25rem 1.5rem;
-  text-align: right;
-  min-height: 96px;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  gap: 0.45rem;
-}
-
-.expression {
-  font-size: 1rem;
-  font-weight: 400;
+.eyebrow {
+  font-size: 0.95rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
   color: var(--text-secondary);
-  min-height: 1.5em;
-  overflow-wrap: anywhere;
+  margin: 0;
 }
 
-.result {
-  font-size: clamp(2.5rem, 6vw, 3.2rem);
-  font-weight: 600;
-  letter-spacing: 0.05em;
+.counter {
+  font-size: clamp(4.5rem, 20vw, 6.75rem);
+  font-weight: 700;
+  line-height: 0.9;
+  letter-spacing: -0.04em;
 }
 
-.keys {
+.subtitle {
+  margin: 0;
+  font-size: 1.05rem;
+  color: var(--text-secondary);
+}
+
+.scroll-hint {
+  font-size: 0.95rem;
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.thermometer-card {
+  position: sticky;
+  top: clamp(1.25rem, 6vw, 2rem);
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 0.75rem;
+  gap: 1.75rem;
+  justify-items: center;
 }
 
-.key {
-  background: rgba(255, 255, 255, 0.12);
-  border: none;
-  color: inherit;
-  border-radius: 20px;
+.thermometer-title {
+  margin: 0;
   font-size: 1.35rem;
-  font-weight: 500;
-  padding: 1rem;
-  transition: transform 0.12s ease, box-shadow 0.12s ease, background-color 0.12s ease;
-  cursor: pointer;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12);
-}
-
-.key:focus-visible {
-  outline: 3px solid var(--green-300);
-  outline-offset: 3px;
-}
-
-.key:active {
-  transform: scale(0.98);
-}
-
-.key--function {
-  background: rgba(62, 180, 137, 0.35);
-  color: #ebfff6;
-}
-
-.key--operator {
-  background: linear-gradient(120deg, var(--purple-400), var(--green-500));
-  color: #fef6ff;
   font-weight: 600;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.25);
+  text-align: center;
 }
 
-.key--operator[data-action='equals'] {
-  background: linear-gradient(120deg, var(--green-500), var(--purple-600));
+.thermometer {
+  --fill-progress: 0;
+  --fill-color: #38bdf8;
+  --fill-color-light: #bae6fd;
+  display: grid;
+  justify-items: center;
+  gap: 1.25rem;
 }
 
-.key--wide {
-  grid-column: span 2;
+.thermometer__stem {
+  padding: 0.4rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.25);
 }
 
-@media (max-width: 480px) {
-  .calculator {
-    border-radius: 24px;
-    padding: 1.25rem 1rem 1rem;
+.thermometer__track {
+  position: relative;
+  width: 78px;
+  height: 280px;
+  border-radius: 999px;
+  background: linear-gradient(180deg, rgba(148, 163, 184, 0.35), rgba(30, 41, 59, 0.65));
+  overflow: hidden;
+}
+
+.thermometer__fill {
+  position: absolute;
+  inset: 0;
+  transform-origin: center bottom;
+  transform: scaleY(var(--fill-progress));
+  background: linear-gradient(180deg, var(--fill-color-light) 0%, var(--fill-color) 100%);
+  transition: transform 120ms ease-out;
+}
+
+.thermometer__bulb {
+  position: relative;
+  width: 140px;
+  height: 140px;
+  border-radius: 50%;
+  background: var(--fill-color);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: inset 0 -10px 30px rgba(15, 23, 42, 0.4), 0 18px 45px rgba(14, 116, 144, 0.35);
+  transition: background-color 150ms ease-out, box-shadow 150ms ease-out;
+}
+
+.thermometer__bulb::after {
+  content: '';
+  position: absolute;
+  inset: 18%;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.75), transparent 62%);
+  mix-blend-mode: screen;
+}
+
+.temperature-readout {
+  font-size: 1.1rem;
+  color: var(--text-secondary);
+}
+
+.temperature-value {
+  font-size: 1.6rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.story {
+  display: grid;
+  gap: 1rem;
+}
+
+.story h2 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.story p {
+  margin: 0;
+  color: var(--text-secondary);
+  line-height: 1.7;
+}
+
+@media (max-width: 420px) {
+  .thermometer__track {
+    width: 64px;
+    height: 240px;
   }
 
-  .key {
-    border-radius: 16px;
-    font-size: 1.2rem;
-    padding: 0.9rem 0.85rem;
+  .thermometer__bulb {
+    width: 120px;
+    height: 120px;
   }
 }


### PR DESCRIPTION
## Summary
- replace the old calculator layout with a scroll-driven counter and thermometer interface
- add glassmorphism-inspired styling tailored for mobile viewports
- implement scroll listeners that increase the counter and animate the thermometer fill and color gradient

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68f6f16b3600832d9bb199f120627252